### PR TITLE
#2: Add CORS into header in case we needed

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -199,6 +199,9 @@ def respond(err, res=None):
 		'body': str(err) if err else json.dumps(res),
 		'headers': {
 			'Content-Type': 'application/json',
+			"Access-Control-Allow-Origin": "*", 
+			"Access-Control-Allow-Methods": "GET, POST, DELETE, PUT", 
+			"Access-Control-Allow-Headers": "Content-Type, Authorization" 
 		},
 	}
 


### PR DESCRIPTION
This PR is for #2 to add CORS on the code side. We may need to enable this in the AWS console as well